### PR TITLE
Removed `alias_method :extended, :included` from modules; that's not how 

### DIFF
--- a/lib/adaptive_payments/client_details.rb
+++ b/lib/adaptive_payments/client_details.rb
@@ -13,8 +13,6 @@ module AdaptivePayments
           attribute :client_customer_id,    String, :param => "clientDetails.customerId"
         end
       end
-
-      alias_method :extended, :included
     end
   end
 end

--- a/lib/adaptive_payments/fault_message.rb
+++ b/lib/adaptive_payments/fault_message.rb
@@ -18,8 +18,6 @@ module AdaptivePayments
           def_delegator :first_error, :parameters, :error_parameters
         end
       end
-
-      alias_method :extended, :included
     end
 
     def first_error

--- a/lib/adaptive_payments/phone.rb
+++ b/lib/adaptive_payments/phone.rb
@@ -8,8 +8,6 @@ module AdaptivePayments
           attribute :phone_extension,    String, :param => "phone.extension"
         end
       end
-
-      alias_method :extended, :included
     end
   end
 end

--- a/lib/adaptive_payments/request_envelope.rb
+++ b/lib/adaptive_payments/request_envelope.rb
@@ -7,8 +7,6 @@ module AdaptivePayments
           attribute :error_language,  String, :param => "requestEnvelope.errorLanguage", :default => "en_US"
         end
       end
-
-      alias_method :extended, :included
     end
   end
 end

--- a/lib/adaptive_payments/response_envelope.rb
+++ b/lib/adaptive_payments/response_envelope.rb
@@ -14,8 +14,6 @@ module AdaptivePayments
           end
         end
       end
-
-      alias_method :extended, :included
     end
   end
 end


### PR DESCRIPTION
Removed `alias_method :extended, :included` from modules; that's not how it works.
