### PR TITLE
RSpec in Rakefile: "rake spec" or just "rake".

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,8 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+task :default => :spec
+
+RSpec::Core::RakeTask.new do |t|
+  t.pattern = 'spec/**/*_spec.rb'
+end


### PR DESCRIPTION
This is an expected standard in the Ruby community.
