### PR TITLE
Update link to new PayPal Adaptive Payments API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Adaptive Payments is a very extensive API with a lot of endpoints and a lot
 of fields within each request. It wouldn't be wise to attempt to document them
 all here, but the official API documentation covers everything in detail.
 
-https://cms.paypal.com/cms_content/US/en_US/files/developer/PP_AdaptivePayments.pdf
+https://www.paypalobjects.com/webstatic/en_US/developer/docs/pdf/pp_adaptivepayments.pdf
 
 Just ruby-ize the fields (i.e. underscores, not camel case) and open up the
 request/response classes in this repository to get a feel for how this all works.


### PR DESCRIPTION
Hi, I just notice that the link was not up to date, so I made a commit with the new link.
