### PR TITLE
Update RSpec to version 3.1.

### DIFF
--- a/pp-adaptive.gemspec
+++ b/pp-adaptive.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency     "virtus",      "~> 1.0.0"
   s.add_runtime_dependency     "json"
 
-  s.add_development_dependency "rspec",       ">= 2.10"
+  s.add_development_dependency "rspec",       "~> 3.1"
   s.add_development_dependency "rake"
 end

--- a/spec/public/cancel_preapproval_request_spec.rb
+++ b/spec/public/cancel_preapproval_request_spec.rb
@@ -4,12 +4,16 @@ describe AdaptivePayments::CancelPreapprovalRequest do
   it_behaves_like "a RequestEnvelope"
 
   subject         { AdaptivePayments::CancelPreapprovalRequest }
-  its(:operation) { should == :CancelPreapproval }
+
+  describe '#operation' do
+    subject { super().operation }
+    it { is_expected.to eq(:CancelPreapproval) }
+  end
 
   let(:request) { AdaptivePayments::CancelPreapprovalRequest.new(:preapproval_key => "ABCD-1234") }
   let(:json)    { JSON.parse(request.to_json) }
 
   it "maps #preapproval_key to ['preapprovalKey']" do
-    json["preapprovalKey"].should == "ABCD-1234"
+    expect(json["preapprovalKey"]).to eq("ABCD-1234")
   end
 end

--- a/spec/public/client_spec.rb
+++ b/spec/public/client_spec.rb
@@ -1,17 +1,17 @@
 require "spec_helper"
 
 describe AdaptivePayments::Client do
-  let(:rest_client)   { double(:post => '{}').tap { |d| d.stub(:[] => d) } }
+  let(:rest_client)   { double(:post => '{}').tap { |d| allow(d).to receive_messages(:[] => d) } }
   let(:request_class) { double(:operation => :Refund, :build_response => nil) }
   let(:request)       { double(:class => request_class, :to_json => '{}') }
   let(:client)        { AdaptivePayments::Client.new }
 
   before(:each) do
-    RestClient::Resource.stub(:new).and_return(rest_client)
+    allow(RestClient::Resource).to receive(:new).and_return(rest_client)
   end
 
   it "uses the production endpoint by default" do
-    RestClient::Resource.should_receive(:new) \
+    expect(RestClient::Resource).to receive(:new) \
       .with("https://svcs.paypal.com/AdaptivePayments", an_instance_of(Hash)) \
       .and_return(rest_client)
     client.execute(request)
@@ -19,7 +19,7 @@ describe AdaptivePayments::Client do
 
   it "uses the sandbox when sandbox? is true" do
     client.sandbox = true
-    RestClient::Resource.should_receive(:new) \
+    expect(RestClient::Resource).to receive(:new) \
       .with("https://svcs.sandbox.paypal.com/AdaptivePayments", an_instance_of(Hash)) \
       .and_return(rest_client)
     client.execute(request)
@@ -27,7 +27,7 @@ describe AdaptivePayments::Client do
 
   it "sends the user ID in the headers to the endpoint" do
     client.user_id = "a.user.id"
-    RestClient::Resource.should_receive(:new) \
+    expect(RestClient::Resource).to receive(:new) \
       .with(/^https:\/\/.*/, :headers => hash_including("X-PAYPAL-SECURITY-USERID" => "a.user.id")) \
       .and_return(rest_client)
     client.execute(request)
@@ -35,7 +35,7 @@ describe AdaptivePayments::Client do
 
   it "sends the password in the headers to the endpoint" do
     client.password = "123456"
-    RestClient::Resource.should_receive(:new) \
+    expect(RestClient::Resource).to receive(:new) \
       .with(/^https:\/\/.*/, :headers => hash_including("X-PAYPAL-SECURITY-PASSWORD" => "123456")) \
       .and_return(rest_client)
     client.execute(request)
@@ -43,7 +43,7 @@ describe AdaptivePayments::Client do
 
   it "sends the signature in the headers to the endpoint" do
     client.signature = "a.signature"
-    RestClient::Resource.should_receive(:new) \
+    expect(RestClient::Resource).to receive(:new) \
       .with(/^https:\/\/.*/, :headers => hash_including("X-PAYPAL-SECURITY-SIGNATURE" => "a.signature")) \
       .and_return(rest_client)
     client.execute(request)
@@ -51,47 +51,47 @@ describe AdaptivePayments::Client do
 
   it "sends the application ID in the headers to the endpoint" do
     client.app_id = "an.app.id"
-    RestClient::Resource.should_receive(:new) \
+    expect(RestClient::Resource).to receive(:new) \
       .with(/^https:\/\/.*/, :headers => hash_including("X-PAYPAL-APPLICATION-ID" => "an.app.id")) \
       .and_return(rest_client)
     client.execute(request)
   end
 
   it "sets the request format to JSON" do
-    RestClient::Resource.should_receive(:new) \
+    expect(RestClient::Resource).to receive(:new) \
       .with(/^https:\/\/.*/, :headers => hash_including("X-PAYPAL-REQUEST-DATA-FORMAT" => "JSON")) \
       .and_return(rest_client)
     client.execute(request)
   end
 
   it "sets the response format to JSON" do
-    RestClient::Resource.should_receive(:new) \
+    expect(RestClient::Resource).to receive(:new) \
       .with(/^https:\/\/.*/, :headers => hash_including("X-PAYPAL-RESPONSE-DATA-FORMAT" => "JSON")) \
       .and_return(rest_client)
     client.execute(request)
   end
 
   it "sends requests to the given API operation" do
-    request.class.stub(:operation => :Preapproval)
-    rest_client.should_receive(:[]).with("Preapproval")
+    allow(request.class).to receive_messages(:operation => :Preapproval)
+    expect(rest_client).to receive(:[]).with("Preapproval")
     client.execute(request)
   end
 
   it "uses the request class to build a response" do
     response = double(:response)
-    request_class.should_receive(:build_response).and_return(response)
-    client.execute(request).should == response
+    expect(request_class).to receive(:build_response).and_return(response)
+    expect(client.execute(request)).to eq(response)
   end
 
   it "allows passing a Symbol + Hash instead of a full request object" do
-    client.execute(:Refund, {}).should be_a_kind_of(AdaptivePayments::RefundResponse)
+    expect(client.execute(:Refund, {})).to be_a_kind_of(AdaptivePayments::RefundResponse)
   end
 
   it "yields the response object" do
     response = double(:response)
-    request_class.should_receive(:build_response).and_return(response)
+    expect(request_class).to receive(:build_response).and_return(response)
     ret_val = nil
     client.execute(request) { |r| ret_val = r }
-    ret_val.should == response
+    expect(ret_val).to eq(response)
   end
 end

--- a/spec/public/convert_currency_request_spec.rb
+++ b/spec/public/convert_currency_request_spec.rb
@@ -4,7 +4,11 @@ describe AdaptivePayments::ConvertCurrencyRequest do
   it_behaves_like "a RequestEnvelope"
 
   subject         { AdaptivePayments::ConvertCurrencyRequest }
-  its(:operation) { should == :ConvertCurrency }
+
+  describe '#operation' do
+    subject { super().operation }
+    it { is_expected.to eq(:ConvertCurrency) }
+  end
 
   let(:request) do
     AdaptivePayments::ConvertCurrencyRequest.new(
@@ -19,11 +23,11 @@ describe AdaptivePayments::ConvertCurrencyRequest do
   let(:json) { JSON.parse(request.to_json) }
 
   it "maps #currency.first.amount to ['baseAmountList']['currency'][0]['amount']" do
-    json["baseAmountList"]["currency"][0]["amount"].should == "14.99"
+    expect(json["baseAmountList"]["currency"][0]["amount"]).to eq("14.99")
   end
 
   it "maps #currency.first.amount to ['baseAmountList']['currency'][1]['amount']" do
-    json["baseAmountList"]["currency"][1]["amount"].should == "129.99"
+    expect(json["baseAmountList"]["currency"][1]["amount"]).to eq("129.99")
   end
 
 end

--- a/spec/public/convert_currency_response_spec.rb
+++ b/spec/public/convert_currency_response_spec.rb
@@ -44,19 +44,19 @@ describe AdaptivePayments::ConvertCurrencyResponse do
   end
 
   it "maps ['estimatedAmountTable']['currencyConversionList']['baseAmount']['code'] to #currency_conversions[0].base_currency_code" do
-    response.currency_conversions.first.base_currency_code.should == "USD"
+    expect(response.currency_conversions.first.base_currency_code).to eq("USD")
   end
 
   it "maps ['estimatedAmountTable']['currencyConversionList']['baseAmount']['amount'] to #currency_conversions[0].base_currency_amount" do
-    response.currency_conversions.first.base_currency_amount.should == BigDecimal.new("14.99")
+    expect(response.currency_conversions.first.base_currency_amount).to eq(BigDecimal.new("14.99"))
   end
 
   it "maps ['estimatedAmountTable']['currencyConversionList']['currencyList']['currency][0]['code'] to #currency_conversions[0].currencies[0].currency_code" do
-    response.currency_conversions.first.currencies.first.code.should == "JPY"
+    expect(response.currency_conversions.first.currencies.first.code).to eq("JPY")
   end
 
   it "maps ['estimatedAmountTable']['currencyConversionList']['currencyList']['currency][0]['amount'] to #currency_conversions[0].currencies[0].currency_amount" do
-    response.currency_conversions.first.currencies.first.amount.should == BigDecimal.new("1733")
+    expect(response.currency_conversions.first.currencies.first.amount).to eq(BigDecimal.new("1733"))
   end
 
 end

--- a/spec/public/execute_payment_request_spec.rb
+++ b/spec/public/execute_payment_request_spec.rb
@@ -4,7 +4,11 @@ describe AdaptivePayments::ExecutePaymentRequest do
   it_behaves_like "a RequestEnvelope"
 
   subject         { AdaptivePayments::ExecutePaymentRequest }
-  its(:operation) { should == :ExecutePayment }
+
+  describe '#operation' do
+    subject { super().operation }
+    it { is_expected.to eq(:ExecutePayment) }
+  end
 
   let(:request) do
     AdaptivePayments::ExecutePaymentRequest.new(
@@ -17,14 +21,14 @@ describe AdaptivePayments::ExecutePaymentRequest do
   let(:json) { JSON.parse(request.to_json) }
 
   it "maps #action_type to ['actionType']" do
-    json["actionType"].should == "PAY"
+    expect(json["actionType"]).to eq("PAY")
   end
 
   it "maps #pay_key to ['payKey']" do
-    json["payKey"].should == "ABCD-1234"
+    expect(json["payKey"]).to eq("ABCD-1234")
   end
 
   it "maps #funding_plan_id to ['fundingPlanId']" do
-    json["fundingPlanId"].should == "funding123"
+    expect(json["fundingPlanId"]).to eq("funding123")
   end
 end

--- a/spec/public/execute_payment_response_spec.rb
+++ b/spec/public/execute_payment_response_spec.rb
@@ -37,30 +37,30 @@ describe AdaptivePayments::ExecutePaymentResponse do
   end
 
   it "maps ['paymentExecStatus'] to #payment_exec_status" do
-    response.payment_exec_status.should == "Completed"
+    expect(response.payment_exec_status).to eq("Completed")
   end
 
   it "maps ['payErrorList']['payError'][0]['receiver']['email'] to #pay_errors.first.receiver_email" do
-    response.pay_errors.first.receiver_email.should == "bob@site.com"
+    expect(response.pay_errors.first.receiver_email).to eq("bob@site.com")
   end
 
   it "maps ['payErrorList']['payError'][0]['receiver']['amount'] to #pay_errors.first.receiver_amount" do
-    response.pay_errors.first.receiver_amount.should == BigDecimal("5.00")
+    expect(response.pay_errors.first.receiver_amount).to eq(BigDecimal("5.00"))
   end
 
   it "maps ['payErrorList']['payError'][0]['error']['domain'] to #pay_errors.first.error_domain" do
-    response.pay_errors.first.error_domain.should == "APPLICATION"
+    expect(response.pay_errors.first.error_domain).to eq("APPLICATION")
   end
 
   it "maps ['payErrorList']['payError'][0]['error']['message'] to #pay_errors.first.error_message" do
-    response.pay_errors.first.error_message.should == "there was an error"
+    expect(response.pay_errors.first.error_message).to eq("there was an error")
   end
 
   it "maps ['payErrorList']['payError'][1]['receiver']['email'] to #pay_errors.last.receiver_email" do
-    response.pay_errors.last.receiver_email.should == "sally@site.com"
+    expect(response.pay_errors.last.receiver_email).to eq("sally@site.com")
   end
 
   it "maps ['payErrorList']['payError'][1]['error']['message'] to #pay_errors.last.error_message" do
-    response.pay_errors.last.error_message.should == "there was another error"
+    expect(response.pay_errors.last.error_message).to eq("there was another error")
   end
 end

--- a/spec/public/get_payment_options_request_spec.rb
+++ b/spec/public/get_payment_options_request_spec.rb
@@ -4,12 +4,16 @@ describe AdaptivePayments::GetPaymentOptionsRequest do
   it_behaves_like "a RequestEnvelope"
 
   subject         { AdaptivePayments::GetPaymentOptionsRequest }
-  its(:operation) { should == :GetPaymentOptions }
+
+  describe '#operation' do
+    subject { super().operation }
+    it { is_expected.to eq(:GetPaymentOptions) }
+  end
 
   let(:request) { AdaptivePayments::GetPaymentOptionsRequest.new(:pay_key => "ABCD-1234") }
   let(:json)    { JSON.parse(request.to_json) }
 
   it "maps #pay_key to ['payKey']" do
-    json["payKey"].should == "ABCD-1234"
+    expect(json["payKey"]).to eq("ABCD-1234")
   end
 end

--- a/spec/public/get_payment_options_response_spec.rb
+++ b/spec/public/get_payment_options_response_spec.rb
@@ -52,90 +52,90 @@ describe AdaptivePayments::GetPaymentOptionsResponse do
   end
 
   it "maps ['initiatingEntity']['institutionCustomer']['institutionId'] to #institution_id" do
-    response.institution_id.should == "inst123"
+    expect(response.institution_id).to eq("inst123")
   end
 
   it "maps ['initiatingEntity']['institutionCustomer']['firstName'] to #customer_first_name" do
-    response.customer_first_name.should == "Bob"
+    expect(response.customer_first_name).to eq("Bob")
   end
 
   it "maps ['initiatingEntity']['institutionCustomer']['lastName'] to #customer_last_name" do
-    response.customer_last_name.should == "Cat"
+    expect(response.customer_last_name).to eq("Cat")
   end
 
   it "maps ['initiatingEntity']['institutionCustomer']['displayName'] to #customer_display_name" do
-    response.customer_display_name.should == "Bobcat"
+    expect(response.customer_display_name).to eq("Bobcat")
   end
 
   it "maps ['initiatingEntity']['institutionCustomer']['institutionCustomerId'] to #institution_customer_id" do
-    response.institution_customer_id.should == "77"
+    expect(response.institution_customer_id).to eq("77")
   end
 
   it "maps ['initiatingEntity']['institutionCustomer']['countryCode'] to #customer_country_code" do
-    response.customer_country_code.should == "AU"
+    expect(response.customer_country_code).to eq("AU")
   end
 
   it "maps ['initiatingEntity']['institutionCustomer']['email'] to #customer_email" do
-    response.customer_email.should == "bob@site.com"
+    expect(response.customer_email).to eq("bob@site.com")
   end
 
   it "maps ['displayOptions']['emailHeaderImageUrl'] to #email_header_image_url" do
-    response.email_header_image_url.should == "http://site.com/email.png"
+    expect(response.email_header_image_url).to eq("http://site.com/email.png")
   end
 
   it "maps ['displayOptions']['emailMarketingImageUrl'] to #email_marketing_image_url" do
-    response.email_marketing_image_url.should == "http://site.com/marketing.png"
+    expect(response.email_marketing_image_url).to eq("http://site.com/marketing.png")
   end
 
   it "maps ['displayOptions']['headerImageUrl'] to #header_image_url" do
-    response.header_image_url.should == "http://site.com/header.png"
+    expect(response.header_image_url).to eq("http://site.com/header.png")
   end
 
   it "maps ['displayOptions']['businessName'] to #business_na,e" do
-    response.business_name.should == "Bobcats R us"
+    expect(response.business_name).to eq("Bobcats R us")
   end
 
   it "maps ['shippingAddressId'] to #shipping_address_id" do
-    response.shipping_address_id.should == "addr123"
+    expect(response.shipping_address_id).to eq("addr123")
   end
 
   it "maps ['senderOptions']['requireShippingAddressSelection'] to #require_shipping_address_selection? " do
-    response.require_shipping_address_selection?.should be_true
+    expect(response.require_shipping_address_selection?).to be_truthy
   end
 
   it "maps ['receiverOptions'][0]['description'] to #receiver_options.first.description" do
-    response.receiver_options.first.description.should == "Primary receiver"
+    expect(response.receiver_options.first.description).to eq("Primary receiver")
   end
 
   it "maps ['receiverOptions'][0]['customId'] to #receiver_options.first.custom_id" do
-    response.receiver_options.first.custom_id.should == "cust123"
+    expect(response.receiver_options.first.custom_id).to eq("cust123")
   end
 
   it "maps ['receiverOptions'][0]['invoiceData']['totalTax'] to #receiver_options.first.invoice_data.total_tax" do
-    response.receiver_options.first.invoice_data.total_tax.should == BigDecimal("2.00")
+    expect(response.receiver_options.first.invoice_data.total_tax).to eq(BigDecimal("2.00"))
   end
 
   it "maps ['receiverOptions'][0]['invoiceData']['totalShipping'] to #receiver_options.first.invoice_data.total_shipping" do
-    response.receiver_options.first.invoice_data.total_shipping.should == BigDecimal("0.00")
+    expect(response.receiver_options.first.invoice_data.total_shipping).to eq(BigDecimal("0.00"))
   end
 
   it "maps ['receiverOptions'][0]['invoiceData']['item'][0]['name'] to #receiver_options.first.invoice_data.items.first.name" do
-    response.receiver_options.first.invoice_data.items.first.name.should == "Video Game"
+    expect(response.receiver_options.first.invoice_data.items.first.name).to eq("Video Game")
   end
 
   it "maps ['receiverOptions'][0]['invoiceData']['item'][0]['identifier'] to #receiver_options.first.invoice_data.items.first.identifier" do
-    response.receiver_options.first.invoice_data.items.first.identifier.should == "ident123"
+    expect(response.receiver_options.first.invoice_data.items.first.identifier).to eq("ident123")
   end
 
   it "maps ['receiverOptions'][0]['invoiceData']['item'][0]['price'] to #receiver_options.first.invoice_data.items.first.price" do
-    response.receiver_options.first.invoice_data.items.first.price.should == BigDecimal("20.00")
+    expect(response.receiver_options.first.invoice_data.items.first.price).to eq(BigDecimal("20.00"))
   end
 
   it "maps ['receiverOptions'][0]['invoiceData']['item'][0]['itemPrice'] to #receiver_options.first.invoice_data.items.first.item_price" do
-    response.receiver_options.first.invoice_data.items.first.item_price.should == BigDecimal("10.00")
+    expect(response.receiver_options.first.invoice_data.items.first.item_price).to eq(BigDecimal("10.00"))
   end
 
   it "maps ['receiverOptions'][0]['invoiceData']['item'][0]['itemCount'] to #receiver_options.first.invoice_data.items.first.item_count" do
-    response.receiver_options.first.invoice_data.items.first.item_count.should == 2
+    expect(response.receiver_options.first.invoice_data.items.first.item_count).to eq(2)
   end
 end

--- a/spec/public/json_model_spec.rb
+++ b/spec/public/json_model_spec.rb
@@ -15,8 +15,8 @@ describe AdaptivePayments::JsonModel do
     let(:object) { model.new(:an_example => "string", :numeric => 20) }
 
     it "casts inputs to the correct type" do
-      object.an_example.should == "string"
-      object.numeric.should == BigDecimal("20.00")
+      expect(object.an_example).to eq("string")
+      expect(object.numeric).to eq(BigDecimal("20.00"))
     end
   end
 
@@ -24,7 +24,7 @@ describe AdaptivePayments::JsonModel do
     let(:object) { model.new }
 
     it "reads the :default option for a default value" do
-      object.optional.should == "test"
+      expect(object.optional).to eq("test")
     end
   end
 
@@ -33,7 +33,7 @@ describe AdaptivePayments::JsonModel do
       let(:json) { model.new.to_json }
 
       it "omits the empty values" do
-        json.should == '{"optional":"test"}'
+        expect(json).to eq('{"optional":"test"}')
       end
     end
 
@@ -41,7 +41,7 @@ describe AdaptivePayments::JsonModel do
       let(:json) { model.new(:numeric => 10).to_json }
 
       it "formats the decimal to scale 2" do
-        json.should == '{"numeric":"10.00","optional":"test"}'
+        expect(json).to eq('{"numeric":"10.00","optional":"test"}')
       end
     end
 
@@ -49,7 +49,7 @@ describe AdaptivePayments::JsonModel do
       let(:json) { model.new(:an_example => "whatever").to_json }
 
       it "uses the param as the key" do
-        json.should == '{"anExample":"whatever","optional":"test"}'
+        expect(json).to eq('{"anExample":"whatever","optional":"test"}')
       end
     end
   end

--- a/spec/public/node_list_spec.rb
+++ b/spec/public/node_list_spec.rb
@@ -16,7 +16,7 @@ describe AdaptivePayments::NodeList do
 
   describe "default type" do
     it "is a kind of Array" do
-      model.new.children.should be_a_kind_of(Array)
+      expect(model.new.children).to be_a_kind_of(Array)
     end
   end
 
@@ -25,7 +25,7 @@ describe AdaptivePayments::NodeList do
       let(:object) { model.new.tap { |o| o.children << { :example => "anything" } } }
 
       it "coerces hash to instances of the given type" do
-        object.children.first.should be_an_instance_of(child_model)
+        expect(object.children.first).to be_an_instance_of(child_model)
       end
     end
 
@@ -33,7 +33,7 @@ describe AdaptivePayments::NodeList do
       let(:object) { model.new.tap { |o| o.children = [{ :example => "anything" }] } }
 
       it "coerces each member to instances of the given type" do
-        object.children.first.should be_an_instance_of(child_model)
+        expect(object.children.first).to be_an_instance_of(child_model)
       end
     end
   end
@@ -43,7 +43,7 @@ describe AdaptivePayments::NodeList do
       let(:json) { model.new(:children => [{ :example => "whatever" }]).to_json }
 
       it "is present as a child in the output" do
-        json.should == '{"children":[{"example":"whatever"}]}'
+        expect(json).to eq('{"children":[{"example":"whatever"}]}')
       end
     end
 
@@ -51,7 +51,7 @@ describe AdaptivePayments::NodeList do
       let(:json) { model.new.to_json }
 
       it "is omitted from the output" do
-        json.should == '{}'
+        expect(json).to eq('{}')
       end
     end
   end

--- a/spec/public/node_spec.rb
+++ b/spec/public/node_spec.rb
@@ -18,7 +18,7 @@ describe AdaptivePayments::Node do
     let(:child) { model.new.child }
 
     it "is an instance of the boxed type" do
-      child.should be_an_instance_of(child_model)
+      expect(child).to be_an_instance_of(child_model)
     end
   end
 
@@ -26,11 +26,11 @@ describe AdaptivePayments::Node do
     let(:object) { model.new(:child => { :example => "anything" }) }
 
     it "coerces hash to instances of the given type" do
-      object.child.should be_an_instance_of(child_model)
+      expect(object.child).to be_an_instance_of(child_model)
     end
 
     it "maintains the original keys" do
-      object.child.example.should == "anything"
+      expect(object.child.example).to eq("anything")
     end
   end
 
@@ -39,7 +39,7 @@ describe AdaptivePayments::Node do
       let(:json) { model.new(:child => { :example => "whatever" }).to_json }
 
       it "is present as a child in the output" do
-        json.should == '{"child":{"example":"whatever"}}'
+        expect(json).to eq('{"child":{"example":"whatever"}}')
       end
     end
 
@@ -47,7 +47,7 @@ describe AdaptivePayments::Node do
       let(:json) { model.new.to_json }
 
       it "is omitted from the output" do
-        json.should == '{}'
+        expect(json).to eq('{}')
       end
     end
   end

--- a/spec/public/pay_request_spec.rb
+++ b/spec/public/pay_request_spec.rb
@@ -4,7 +4,11 @@ describe AdaptivePayments::PayRequest do
   it_behaves_like "a RequestEnvelope"
 
   subject         { AdaptivePayments::PayRequest }
-  its(:operation) { should == :Pay }
+
+  describe '#operation' do
+    subject { super().operation }
+    it { is_expected.to eq(:Pay) }
+  end
 
   let(:request) do
     AdaptivePayments::PayRequest.new(
@@ -33,119 +37,119 @@ describe AdaptivePayments::PayRequest do
   let(:json) { JSON.parse(request.to_json) }
 
   it "maps #receivers.first.email to ['receiverList']['receiver'][0]['email']" do
-    json["receiverList"]["receiver"][0]["email"].should == "receiver1@site.com"
+    expect(json["receiverList"]["receiver"][0]["email"]).to eq("receiver1@site.com")
   end
 
   it "maps #receivers.last.email to ['receiverList']['receiver'][1]['email']" do
-    json["receiverList"]["receiver"][1]["email"].should == "receiver2@site.com"
+    expect(json["receiverList"]["receiver"][1]["email"]).to eq("receiver2@site.com")
   end
 
   it "maps #receivers.first.amount to ['receiverList']['receiver'][0]['amount']" do
-    json["receiverList"]["receiver"][0]["amount"].should == "20.00"
+    expect(json["receiverList"]["receiver"][0]["amount"]).to eq("20.00")
   end
 
   it "maps #receivers.last.amount to ['receiverList']['receiver'][1]['amount']" do
-    json["receiverList"]["receiver"][1]["amount"].should == "5.00"
+    expect(json["receiverList"]["receiver"][1]["amount"]).to eq("5.00")
   end
 
   it "maps #receivers.last.primary to ['receiverList']['receiver'][1]['primary']" do
-    json["receiverList"]["receiver"][1]["primary"].should == true
+    expect(json["receiverList"]["receiver"][1]["primary"]).to eq(true)
   end
 
   it "maps #payment_type to ['receiverList']['receiver'][0]['paymentType']" do
-    json["receiverList"]["receiver"][0]["paymentType"].should == "DIGITALGOODS"
+    expect(json["receiverList"]["receiver"][0]["paymentType"]).to eq("DIGITALGOODS")
   end
 
   it "maps #allowed_funding_types.first to ['fundingConstraint']['allowedFundingType']['fundingTypeInfo'][0]['fundingType']" do
-    json["fundingConstraint"]["allowedFundingType"]["fundingTypeInfo"][0]["fundingType"].should == "CREDITCARD"
+    expect(json["fundingConstraint"]["allowedFundingType"]["fundingTypeInfo"][0]["fundingType"]).to eq("CREDITCARD")
   end
 
   it "maps #allowed_funding_types.last to ['fundingConstraint']['allowedFundingType']['fundingTypeInfo'][1]['fundingType']" do
-    json["fundingConstraint"]["allowedFundingType"]["fundingTypeInfo"][1]["fundingType"].should == "BALANCE"
+    expect(json["fundingConstraint"]["allowedFundingType"]["fundingTypeInfo"][1]["fundingType"]).to eq("BALANCE")
   end
 
   it "maps #invoice_id to ['receiverList']['receiver'][0]['invoiceId']" do
-    json["receiverList"]["receiver"][0]["invoiceId"].should == "42"
+    expect(json["receiverList"]["receiver"][0]["invoiceId"]).to eq("42")
   end
 
   it "allows setting the first receiver email with #receiver_email" do
     request.receiver_email = "another@receiver.com"
-    json["receiverList"]["receiver"][0]["email"].should == "another@receiver.com"
+    expect(json["receiverList"]["receiver"][0]["email"]).to eq("another@receiver.com")
   end
 
   it "allows setting the first receiver amount with #receiver_amount" do
     request.receiver_amount = 30
-    json["receiverList"]["receiver"][0]["amount"].should == "30.00"
+    expect(json["receiverList"]["receiver"][0]["amount"]).to eq("30.00")
   end
 
   it "allows setting the first receiver phone number with #receiver_phone_number" do
     request.receiver_phone_number = "0431301201"
-    json["receiverList"]["receiver"][0]["phone"]["phoneNumber"].should == "0431301201"
+    expect(json["receiverList"]["receiver"][0]["phone"]["phoneNumber"]).to eq("0431301201")
   end
 
   it "allows setting the first receiver phone country code with #receiver_phone_country_code" do
     request.receiver_phone_country_code = "61"
-    json["receiverList"]["receiver"][0]["phone"]["countryCode"].should == "61"
+    expect(json["receiverList"]["receiver"][0]["phone"]["countryCode"]).to eq("61")
   end
 
   it "allows setting the first receiver phone extension with #receiver_phone_extension" do
     request.receiver_phone_extension = "033"
-    json["receiverList"]["receiver"][0]["phone"]["extension"].should == "033"
+    expect(json["receiverList"]["receiver"][0]["phone"]["extension"]).to eq("033")
   end
 
   it "maps #action_type to ['actionType']" do
-    json["actionType"].should == "PAY"
+    expect(json["actionType"]).to eq("PAY")
   end
 
   it "maps #preapproval_key to ['preapprovalKey']" do
-    json["preapprovalKey"].should == "ABCD-1234"
+    expect(json["preapprovalKey"]).to eq("ABCD-1234")
   end
 
   it "maps #pin to ['pin']" do
-    json["pin"].should == "1234"
+    expect(json["pin"]).to eq("1234")
   end
 
   it "maps #currency_code to ['currencyCode']" do
-    json["currencyCode"].should == "USD"
+    expect(json["currencyCode"]).to eq("USD")
   end
 
   it "maps #cancel_url to ['cancelUrl']" do
-    json["cancelUrl"].should == "http://site.com/cancelled"
+    expect(json["cancelUrl"]).to eq("http://site.com/cancelled")
   end
 
   it "maps #return_url to ['returnUrl']" do
-    json["returnUrl"].should == "http://site.com/success"
+    expect(json["returnUrl"]).to eq("http://site.com/success")
   end
 
   it "maps #ipn_notification_url to ['ipnNotificationUrl']" do
-    json["ipnNotificationUrl"].should == "http://site.com/ipn"
+    expect(json["ipnNotificationUrl"]).to eq("http://site.com/ipn")
   end
 
   it "maps #sender_email to ['sender']['email']" do
-    json["sender"]["email"].should == "sender@site.com"
+    expect(json["sender"]["email"]).to eq("sender@site.com")
   end
 
   it "maps #sender_phone_country_code to ['sender']['phone']['countryCode']" do
-    json["sender"]["phone"]["countryCode"].should == "61"
+    expect(json["sender"]["phone"]["countryCode"]).to eq("61")
   end
 
   it "maps #sender_phone_number to ['sender']['phone']['phoneNumber']" do
-    json["sender"]["phone"]["phoneNumber"].should == "0431300200"
+    expect(json["sender"]["phone"]["phoneNumber"]).to eq("0431300200")
   end
 
   it "maps #sender_phone_extension to ['sender']['phone']['extension']" do
-    json["sender"]["phone"]["extension"].should == "033"
+    expect(json["sender"]["phone"]["extension"]).to eq("033")
   end
 
   it "maps #reverse_parallel_payments_on_error to ['reverseAllParallelPaymentsOnError']" do
-    json["reverseAllParallelPaymentsOnError"].should == false
+    expect(json["reverseAllParallelPaymentsOnError"]).to eq(false)
   end
 
   it "maps #tracking_id to ['trackingId']" do
-    json["trackingId"].should == "anything.id"
+    expect(json["trackingId"]).to eq("anything.id")
   end
 
   it "maps #memo to 'memo'" do
-    json["memo"].should == "a personal note"
+    expect(json["memo"]).to eq("a personal note")
   end
 end

--- a/spec/public/pay_response_spec.rb
+++ b/spec/public/pay_response_spec.rb
@@ -76,122 +76,122 @@ describe AdaptivePayments::PayResponse do
   end
 
   it "maps ['payKey'] to #pay_key" do
-    response.pay_key.should == "ABCD-1234"
+    expect(response.pay_key).to eq("ABCD-1234")
   end
 
   it "maps ['paymentExecStatus'] to #payment_exec_status" do
-    response.payment_exec_status.should == "COMPLETED"
+    expect(response.payment_exec_status).to eq("COMPLETED")
   end
 
   it "maps ['defaultFundingPlan']['fundingPlanId'] to #funding_plan_id" do
-    response.funding_plan_id.should == "XXX123"
+    expect(response.funding_plan_id).to eq("XXX123")
   end
 
   it "maps ['defaultFundingPlan']['fundingAmount']['amount'] to #funding_amount" do
-    response.funding_amount.should == BigDecimal("100.00")
+    expect(response.funding_amount).to eq(BigDecimal("100.00"))
   end
 
   it "maps ['defaultFundingPlan']['fundingAmount']['code'] to #funding_currency_code" do
-    response.funding_currency_code.should == "USD"
+    expect(response.funding_currency_code).to eq("USD")
   end
 
   it "maps ['defaultFundingPlan']['senderFees']['amount'] to #sender_fees_amount" do
-    response.sender_fees_amount.should == BigDecimal("6.00")
+    expect(response.sender_fees_amount).to eq(BigDecimal("6.00"))
   end
 
   it "maps ['defaultFundingPlan']['senderFees']['code'] to #sender_fees_currency_code" do
-    response.sender_fees_currency_code.should == "USD"
+    expect(response.sender_fees_currency_code).to eq("USD")
   end
 
   it "maps ['defaultFundingPlan']['backupFundingSource']['fundingSourceId'] to #backup_funding_source.id" do
-    response.backup_funding_source.id.should == "9876"
+    expect(response.backup_funding_source.id).to eq("9876")
   end
 
   it "maps ['defaultFundingPlan']['backupFundingSource']['lastFourOfAccountNumber'] to #backup_funding_source.last_four_digits_of_account" do
-    response.backup_funding_source.last_four_digits_of_account.should == "0000"
+    expect(response.backup_funding_source.last_four_digits_of_account).to eq("0000")
   end
 
   it "maps ['defaultFundingPlan']['backupFundingSource']['displayName'] to #backup_funding_source.display_name" do
-    response.backup_funding_source.display_name.should == "Primary Account"
+    expect(response.backup_funding_source.display_name).to eq("Primary Account")
   end
 
   it "maps ['defaultFundingPlan']['backupFundingSource']['type'] to #backup_funding_source.type" do
-    response.backup_funding_source.type.should == "CREDITCARD"
+    expect(response.backup_funding_source.type).to eq("CREDITCARD")
   end
 
   it "maps ['defaultFundingPlan']['backupFundingSource']['allowed'] to #backup_funding_source.allowed? " do
-    response.backup_funding_source.should be_allowed
+    expect(response.backup_funding_source).to be_allowed
   end
 
   it "maps ['defaultFundingPlan']['currencyConversion']['from']['amount'] to #from_currency_amount" do
-    response.from_currency_amount.should == BigDecimal("83.33")
+    expect(response.from_currency_amount).to eq(BigDecimal("83.33"))
   end
 
   it "maps ['defaultFundingPlan']['currencyConversion']['from']['code'] to #from_currency_code" do
-    response.from_currency_code.should == "GBP"
+    expect(response.from_currency_code).to eq("GBP")
   end
 
   it "maps ['defaultFundingPlan']['currencyConversion']['to']['amount'] to #to_currency_amount" do
-    response.to_currency_amount.should == BigDecimal("100.00")
+    expect(response.to_currency_amount).to eq(BigDecimal("100.00"))
   end
 
   it "maps ['defaultFundingPlan']['currencyConversion']['to']['code'] to #to_currency_code" do
-    response.to_currency_code.should == "USD"
+    expect(response.to_currency_code).to eq("USD")
   end
 
   it "maps ['defaultFundingPlan']['currencyConversion']['exchangeRate'] to #exchange_rate" do
-    response.exchange_rate.should == BigDecimal("0.8333")
+    expect(response.exchange_rate).to eq(BigDecimal("0.8333"))
   end
 
   it "maps ['defaultFundingPlan']['charge'][0]['charge']['amount'] to #charges.first.amount" do
-    response.charges.first.amount.should == BigDecimal("5.00")
+    expect(response.charges.first.amount).to eq(BigDecimal("5.00"))
   end
 
   it "maps ['defaultFundingPlan']['charge'][0]['charge']['code'] to #charges.first.currency_code" do
-    response.charges.first.currency_code.should == "USD"
+    expect(response.charges.first.currency_code).to eq("USD")
   end
 
   it "maps ['defaultFundingPlan']['charge'][0]['fundingSource']['fundingSourceId'] to #charges.first.funding_source.id" do
-    response.charges.first.funding_source.id.should == "1234"
+    expect(response.charges.first.funding_source.id).to eq("1234")
   end
 
   it "maps ['payErrorList']['payError'][0]['receiver']['email'] to #pay_errors.first.receiver.email" do
-    response.pay_errors.first.receiver.email.should == "bob@site.com"
+    expect(response.pay_errors.first.receiver.email).to eq("bob@site.com")
   end
 
   it "allows access to ['payErrorList']['payError'][0]['receiver']['email'] with #pay_errors.first.receiver_email" do
-    response.pay_errors.first.receiver_email.should == "bob@site.com"
+    expect(response.pay_errors.first.receiver_email).to eq("bob@site.com")
   end
 
   it "maps ['payErrorList']['payError'][0]['receiver']['amount'] to #pay_errors.first.receiver.amount" do
-    response.pay_errors.first.receiver.amount.should == BigDecimal("5.00")
+    expect(response.pay_errors.first.receiver.amount).to eq(BigDecimal("5.00"))
   end
 
   it "allows access to ['payErrorList']['payError'][0]['receiver']['amount'] with #pay_errors.first.receiver_amount" do
-    response.pay_errors.first.receiver_amount.should == BigDecimal("5.00")
+    expect(response.pay_errors.first.receiver_amount).to eq(BigDecimal("5.00"))
   end
 
   it "maps ['payErrorList']['payError'][0]['error']['domain'] to #pay_errors.first.error.domain" do
-    response.pay_errors.first.error.domain.should == "APPLICATION"
+    expect(response.pay_errors.first.error.domain).to eq("APPLICATION")
   end
 
   it "allows access to ['payErrorList']['payError'][0]['error']['domain'] with #pay_errors.first.error_domain" do
-    response.pay_errors.first.error_domain.should == "APPLICATION"
+    expect(response.pay_errors.first.error_domain).to eq("APPLICATION")
   end
 
   it "maps ['payErrorList']['payError'][0]['error']['message'] to #pay_errors.first.error.message" do
-    response.pay_errors.first.error.message.should == "there was an error"
+    expect(response.pay_errors.first.error.message).to eq("there was an error")
   end
 
   it "allows access to ['payErrorList']['payError'][0]['error']['message'] with #pay_errors.first.error_message" do
-    response.pay_errors.first.error_message.should == "there was an error"
+    expect(response.pay_errors.first.error_message).to eq("there was an error")
   end
 
   it "maps ['payErrorList']['payError'][1]['receiver']['email'] to #pay_errors.last.receiver.email" do
-    response.pay_errors.last.receiver.email.should == "sally@site.com"
+    expect(response.pay_errors.last.receiver.email).to eq("sally@site.com")
   end
 
   it "maps ['payErrorList']['payError'][0]['error']['message'] to #pay_errors.last.error.message" do
-    response.pay_errors.last.error.message.should == "there was another error"
+    expect(response.pay_errors.last.error.message).to eq("there was another error")
   end
 end

--- a/spec/public/payment_details_request_spec.rb
+++ b/spec/public/payment_details_request_spec.rb
@@ -4,7 +4,11 @@ describe AdaptivePayments::PaymentDetailsRequest do
   it_behaves_like "a RequestEnvelope"
 
   subject         { AdaptivePayments::PaymentDetailsRequest }
-  its(:operation) { should == :PaymentDetails }
+
+  describe '#operation' do
+    subject { super().operation }
+    it { is_expected.to eq(:PaymentDetails) }
+  end
 
   let(:request) do
     AdaptivePayments::PaymentDetailsRequest.new(
@@ -17,14 +21,14 @@ describe AdaptivePayments::PaymentDetailsRequest do
   let(:json) { JSON.parse(request.to_json) }
 
   it "maps #pay_key to ['payKey']" do
-    json["payKey"].should == "ABCDEFG-1234"
+    expect(json["payKey"]).to eq("ABCDEFG-1234")
   end
 
   it "maps #transaction_id to ['transactionId']" do
-    json["transactionId"].should == "PPX-123ABC"
+    expect(json["transactionId"]).to eq("PPX-123ABC")
   end
 
   it "maps #tracking_id to ['trackingId']" do
-    json["trackingId"].should == "personal.id"
+    expect(json["trackingId"]).to eq("personal.id")
   end
 end

--- a/spec/public/payment_details_response_spec.rb
+++ b/spec/public/payment_details_response_spec.rb
@@ -74,138 +74,138 @@ describe AdaptivePayments::PaymentDetailsResponse do
   end
 
   it "maps ['cancelUrl'] to #cancel_url" do
-    response.cancel_url.should == "http://site.com/cancelled"
+    expect(response.cancel_url).to eq("http://site.com/cancelled")
   end
 
   it "maps ['returnUrl'] to #return_url" do
-    response.return_url.should == "http://site.com/success"
+    expect(response.return_url).to eq("http://site.com/success")
   end
 
   it "maps ['ipnNotificationUrl'] to #ipn_notification_url" do
-    response.ipn_notification_url.should == "http://site.com/ipn"
+    expect(response.ipn_notification_url).to eq("http://site.com/ipn")
   end
 
   it "maps ['memo'] to #memo" do
-    response.memo.should == "a note to self"
+    expect(response.memo).to eq("a note to self")
   end
 
   it "maps ['currencyCode'] to #currencyCode" do
-    response.currency_code.should == "AUD"
+    expect(response.currency_code).to eq("AUD")
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][0]['transactionId'] to #payments.first.transaction_id" do
-    response.payments.first.transaction_id.should == "ABC123"
+    expect(response.payments.first.transaction_id).to eq("ABC123")
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][0]['transactionStatus'] to #payments.first.transaction_status" do
-    response.payments.first.transaction_status.should == "Completed"
+    expect(response.payments.first.transaction_status).to eq("Completed")
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][0]['receiver']['email'] to #payments.first.receiver_email" do
-    response.payments.first.receiver_email.should == "bob@site.com"
+    expect(response.payments.first.receiver_email).to eq("bob@site.com")
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][0]['receiver']['amount'] to #payments.first.receiver_amount" do
-    response.payments.first.receiver_amount.should == BigDecimal("20.00")
+    expect(response.payments.first.receiver_amount).to eq(BigDecimal("20.00"))
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][0]['receiver']['paymentType'] to #payments.first.payment_type" do
-    response.payments.first.payment_type.should == "DIGITALGOODS"
+    expect(response.payments.first.payment_type).to eq("DIGITALGOODS")
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][0]['receiver']['paymentSubType'] to #payments.first.payment_subtype" do
-    response.payments.first.payment_subtype.should == "SOFTWARE"
+    expect(response.payments.first.payment_subtype).to eq("SOFTWARE")
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][0]['receiver']['invoiceId'] to #payments.first.invoice_id" do
-    response.payments.first.invoice_id.should == "77"
+    expect(response.payments.first.invoice_id).to eq("77")
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][0]['refundedAmount'] to #payments.first.refunded_amount" do
-    response.payments.first.refunded_amount.should == BigDecimal("0.00")
+    expect(response.payments.first.refunded_amount).to eq(BigDecimal("0.00"))
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][0]['pendingRefund'] to #payments.first.pending_refund? " do
-    response.payments.first.should be_pending_refund
+    expect(response.payments.first).to be_pending_refund
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][0]['senderTransactionId'] to #payments.first.sender_transaction_id" do
-    response.payments.first.sender_transaction_id.should == "66"
+    expect(response.payments.first.sender_transaction_id).to eq("66")
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][0]['senderTransactionStatus'] to #payments.first.sender_transaction_status" do
-    response.payments.first.sender_transaction_status.should == "Completed"
+    expect(response.payments.first.sender_transaction_status).to eq("Completed")
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][0]['pendingReason'] to #payments.first.pending_reason" do
-    response.payments.first.pending_reason.should == "none"
+    expect(response.payments.first.pending_reason).to eq("none")
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][1]['transactionId'] to #payments.last.transaction_id" do
-    response.payments.last.transaction_id.should == "ABC456"
+    expect(response.payments.last.transaction_id).to eq("ABC456")
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][1]['transactionStatus'] to #payments.last.transaction_status" do
-    response.payments.last.transaction_status.should == "Pending"
+    expect(response.payments.last.transaction_status).to eq("Pending")
   end
 
   it "maps ['paymentInfoList']['paymentInfo'][1]['receiver']['email'] to #payments.last.receiver_email" do
-    response.payments.last.receiver_email.should == "another@site.com"
+    expect(response.payments.last.receiver_email).to eq("another@site.com")
   end
 
   it "maps ['status'] to #status" do
-    response.status.should == "Completed"
+    expect(response.status).to eq("Completed")
   end
 
   it "maps ['trackingId'] to #tracking_id" do
-    response.tracking_id.should == "tracking123"
+    expect(response.tracking_id).to eq("tracking123")
   end
 
   it "maps ['payKey'] to #pay_key" do
-    response.pay_key.should == "pay123"
+    expect(response.pay_key).to eq("pay123")
   end
 
   it "maps ['actionType'] to #actionType" do
-    response.action_type.should == "PAY"
+    expect(response.action_type).to eq("PAY")
   end
 
   it "maps ['feesPayer'] to #fees_payer" do
-    response.fees_payer.should == "SENDER"
+    expect(response.fees_payer).to eq("SENDER")
   end
 
   it "maps ['reverseAllParallelPaymentsOnError'] to #reverse_parallel_payments_on_error? " do
-    response.reverse_parallel_payments_on_error?.should be_true
+    expect(response.reverse_parallel_payments_on_error?).to be_truthy
   end
 
   it "maps ['preapprovalKey'] to #preapproval_key" do
-    response.preapproval_key.should == "PREAPP123"
+    expect(response.preapproval_key).to eq("PREAPP123")
   end
 
   it "maps ['fundingConstraint']['allowedFundingType']['fundingTypeInfo'][0]['fundingType'] to #allowed_funding_types.first" do
-    response.allowed_funding_types.first.should == "CREDITCARD"
+    expect(response.allowed_funding_types.first).to eq("CREDITCARD")
   end
 
   it "maps ['fundingConstraint']['allowedFundingType']['fundingTypeInfo'][1]['fundingType'] to #allowed_funding_types.last" do
-    response.allowed_funding_types.last.should == "BALANCE"
+    expect(response.allowed_funding_types.last).to eq("BALANCE")
   end
 
   it "maps ['sender']['email'] to #sender_email" do
-    response.sender_email.should == "sender@site.com"
+    expect(response.sender_email).to eq("sender@site.com")
   end
 
   it "maps ['sender']['useCredentials'] to #use_sender_credentials? " do
-    response.use_sender_credentials?.should be_false
+    expect(response.use_sender_credentials?).to be_falsey
   end
 
   it "maps ['sender']['phone']['countryCode'] to #sender_phone_country_code" do
-    response.sender_phone_country_code.should == "1"
+    expect(response.sender_phone_country_code).to eq("1")
   end
 
   it "maps ['sender']['phone']['phoneNumber'] to #sender_phone_number" do
-    response.sender_phone_number.should == "456789123"
+    expect(response.sender_phone_number).to eq("456789123")
   end
 
   it "maps ['sender']['phone']['extension'] to #sender_phone_extension" do
-    response.sender_phone_extension.should == "444"
+    expect(response.sender_phone_extension).to eq("444")
   end
 end

--- a/spec/public/preapproval_details_request_spec.rb
+++ b/spec/public/preapproval_details_request_spec.rb
@@ -4,7 +4,11 @@ describe AdaptivePayments::PreapprovalDetailsRequest do
   it_behaves_like "a RequestEnvelope"
 
   subject         { AdaptivePayments::PreapprovalDetailsRequest }
-  its(:operation) { should == :PreapprovalDetails }
+
+  describe '#operation' do
+    subject { super().operation }
+    it { is_expected.to eq(:PreapprovalDetails) }
+  end
 
   let(:request) do
     AdaptivePayments::PreapprovalDetailsRequest.new(
@@ -16,10 +20,10 @@ describe AdaptivePayments::PreapprovalDetailsRequest do
   let(:json) { JSON.parse(request.to_json) }
 
   it "maps #preapproval_key to ['preapprovalKey']" do
-    json["preapprovalKey"].should == "ABCDEFG-1234"
+    expect(json["preapprovalKey"]).to eq("ABCDEFG-1234")
   end
 
   it "maps #get_billing_address to ['getBillingAddress']" do
-    json["getBillingAddress"].should == true
+    expect(json["getBillingAddress"]).to eq(true)
   end
 end

--- a/spec/public/preapproval_details_response_spec.rb
+++ b/spec/public/preapproval_details_response_spec.rb
@@ -63,138 +63,138 @@ describe AdaptivePayments::PreapprovalDetailsResponse do
   end
 
   it "maps ['approved'] to #approved" do
-    response.approved.should be_false
+    expect(response.approved).to be_falsey
   end
 
   it "maps ['cancelUrl'] to #cancel_url" do
-    response.cancel_url.should == "http://site.com/cancelled"
+    expect(response.cancel_url).to eq("http://site.com/cancelled")
   end
 
   it "maps ['returnUrl'] to #return_url" do
-    response.return_url.should == "http://site.com/success"
+    expect(response.return_url).to eq("http://site.com/success")
   end
 
   it "maps ['ipnNotificationUrl'] to #ipn_notification_url" do
-    response.ipn_notification_url.should == "http://site.com/ipn"
+    expect(response.ipn_notification_url).to eq("http://site.com/ipn")
   end
 
   it "maps ['currencyCode'] to #currency_code" do
-    response.currency_code.should == "USD"
+    expect(response.currency_code).to eq("USD")
   end
 
   it "maps ['maxTotalAmountOfAllPayments'] to #max_total_amount" do
-    response.max_total_amount.should == BigDecimal('680.00')
+    expect(response.max_total_amount).to eq(BigDecimal('680.00'))
   end
 
   it "maps ['startingDate'] to #starting_date" do
-    response.starting_date.should == DateTime.new(2011, 9, 22, 12, 37, 7)
+    expect(response.starting_date).to eq(DateTime.new(2011, 9, 22, 12, 37, 7))
   end
 
   it "maps ['endingDate'] to #ending_date" do
-    response.ending_date.should == DateTime.new(2012, 9, 22, 12, 37, 7)
+    expect(response.ending_date).to eq(DateTime.new(2012, 9, 22, 12, 37, 7))
   end
 
   it "maps ['maxAmountPerPayment'] to #max_amount_per_payment" do
-    response.max_amount_per_payment.should == BigDecimal('60.00')
+    expect(response.max_amount_per_payment).to eq(BigDecimal('60.00'))
   end
 
   it "maps ['paymentPeriod'] to #payment_period" do
-    response.payment_period.should == "MONTHLY"
+    expect(response.payment_period).to eq("MONTHLY")
   end
 
   it "maps ['curPayments'] to #current_payments" do
-    response.current_payments.should == 2
+    expect(response.current_payments).to eq(2)
   end
 
   it "maps ['curPaymentsAmount'] to #current_payments_amount" do
-    response.current_payments_amount.should == BigDecimal('100.00')
+    expect(response.current_payments_amount).to eq(BigDecimal('100.00'))
   end
 
   it "maps ['curPeriodAttempts'] to #current_period_attempts" do
-    response.current_period_attempts.should == 1
+    expect(response.current_period_attempts).to eq(1)
   end
 
   it "maps ['curPeriodEndingDate'] to #current_period_ending_date" do
-    response.current_period_ending_date.should == DateTime.new(2011, 9, 30, 12, 37, 7)
+    expect(response.current_period_ending_date).to eq(DateTime.new(2011, 9, 30, 12, 37, 7))
   end
 
   it "maps ['dateOfMonth'] to #date_of_month" do
-    response.date_of_month.should == 15
+    expect(response.date_of_month).to eq(15)
   end
 
   it "maps ['dayOfWeek'] to #day_of_week" do
-    response.day_of_week.should == "FRIDAY"
+    expect(response.day_of_week).to eq("FRIDAY")
   end
 
   it "maps ['pinType'] to #pin_type" do
-    response.pin_type.should == "NOT_REQUIRED"
+    expect(response.pin_type).to eq("NOT_REQUIRED")
   end
 
   it "maps ['senderEmail'] to #sender_email" do
-    response.sender_email.should == "bob@gmail.com"
+    expect(response.sender_email).to eq("bob@gmail.com")
   end
 
   it "maps ['memo'] to #memo" do
-    response.memo.should == "some memo"
+    expect(response.memo).to eq("some memo")
   end
 
   it "maps ['status'] to #status" do
-    response.status.should == "ACTIVE"
+    expect(response.status).to eq("ACTIVE")
   end
 
   it "maps ['feesPayer'] to #fees_payer" do
-    response.fees_payer.should == "SENDER"
+    expect(response.fees_payer).to eq("SENDER")
   end
 
   it "maps ['displayMaxTotalAmount'] to #display_max_total_amount? " do
-    response.display_max_total_amount.should be_true
+    expect(response.display_max_total_amount).to be_truthy
   end
 
   it "maps ['addressList']['address'][0]['addressId'] to #addresses.first.id" do
-    response.addresses.first.id.should == "abc123"
+    expect(response.addresses.first.id).to eq("abc123")
   end
 
   it "maps ['addressList']['address'][0]['addresseeName'] to #addresses.first.addressee_name" do
-    response.addresses.first.addressee_name.should == "Bob Cat"
+    expect(response.addresses.first.addressee_name).to eq("Bob Cat")
   end
 
   it "maps ['addressList']['address'][0]['baseAddress']['line1'] to #addresses.first.line1" do
-    response.addresses.first.line1.should == "56 Bobcat St"
+    expect(response.addresses.first.line1).to eq("56 Bobcat St")
   end
 
   it "maps ['addressList']['address'][0]['baseAddress']['line2'] to #addresses.first.line2" do
-    response.addresses.first.line2.should == "Some estate"
+    expect(response.addresses.first.line2).to eq("Some estate")
   end
 
   it "maps ['addressList']['address'][0]['baseAddress']['city'] to #addresses.first.city" do
-    response.addresses.first.city.should == "Bobcaton"
+    expect(response.addresses.first.city).to eq("Bobcaton")
   end
 
   it "maps ['addressList']['address'][0]['baseAddress']['state'] to #addresses.first.state" do
-    response.addresses.first.state.should == "BCT"
+    expect(response.addresses.first.state).to eq("BCT")
   end
 
   it "maps ['addressList']['address'][0]['baseAddress']['postalCode'] to #addresses.first.postal_code" do
-    response.addresses.first.postal_code.should == "BC1 BC2"
+    expect(response.addresses.first.postal_code).to eq("BC1 BC2")
   end
 
   it "maps ['addressList']['address'][0]['baseAddress']['countryCode'] to #addresses.first.country_code" do
-    response.addresses.first.country_code.should == "BC"
+    expect(response.addresses.first.country_code).to eq("BC")
   end
 
   it "maps ['addressList']['address'][0]['baseAddress']['type'] to #addresses.first.type" do
-    response.addresses.first.type.should == "Home"
+    expect(response.addresses.first.type).to eq("Home")
   end
 
   it "maps ['addressList']['address'][1]['addressId'] to #addresses.last.id" do
-    response.addresses.last.id.should == "abc456"
+    expect(response.addresses.last.id).to eq("abc456")
   end
 
   it "maps ['addressList']['address'][1]['addresseeName'] to #addresses.last.addressee_name" do
-    response.addresses.last.addressee_name.should == "Pete Mouse"
+    expect(response.addresses.last.addressee_name).to eq("Pete Mouse")
   end
 
   it "maps ['addressList']['address'][1]['baseAddress']['line1'] to #addresses.last.line1" do
-    response.addresses.last.line1.should == "2 Le Hole"
+    expect(response.addresses.last.line1).to eq("2 Le Hole")
   end
 end

--- a/spec/public/preapproval_request_spec.rb
+++ b/spec/public/preapproval_request_spec.rb
@@ -4,7 +4,11 @@ describe AdaptivePayments::PreapprovalRequest do
   it_behaves_like "a RequestEnvelope"
 
   subject         { AdaptivePayments::PreapprovalRequest }
-  its(:operation) { should == :Preapproval }
+
+  describe '#operation' do
+    subject { super().operation }
+    it { is_expected.to eq(:Preapproval) }
+  end
 
   let(:request) do
     AdaptivePayments::PreapprovalRequest.new(
@@ -32,79 +36,79 @@ describe AdaptivePayments::PreapprovalRequest do
   let(:json) { JSON.parse(request.to_json) }
 
   it "maps #ending_date to ['endingDate']" do
-    json["endingDate"].should == "2011-09-20T07:57:02+10:00"
+    expect(json["endingDate"]).to eq("2011-09-20T07:57:02+10:00")
   end
 
   it "maps #starting_date to ['startingDate']" do
-    json["startingDate"].should == "2011-09-20T07:49:02+05:00"
+    expect(json["startingDate"]).to eq("2011-09-20T07:49:02+05:00")
   end
 
   it "maps #max_total_amount to ['maxTotalAmountOfAllPayments']" do
-    json["maxTotalAmountOfAllPayments"].should == "720.00"
+    expect(json["maxTotalAmountOfAllPayments"]).to eq("720.00")
   end
 
   it "maps #currency_code to ['currencyCode']" do
-    json["currencyCode"].should == "USD"
+    expect(json["currencyCode"]).to eq("USD")
   end
 
   it "maps #cancel_url to ['cancelUrl']" do
-    json["cancelUrl"].should == "http://site.com/cancelled"
+    expect(json["cancelUrl"]).to eq("http://site.com/cancelled")
   end
 
   it "maps #return_url to ['returnUrl']" do
-    json["returnUrl"].should == "http://site.com/succeeded"
+    expect(json["returnUrl"]).to eq("http://site.com/succeeded")
   end
 
   it "maps #ipn_notification_url to ['ipnNotificationUrl']" do
-    json["ipnNotificationUrl"].should == "http://site.com/ipn"
+    expect(json["ipnNotificationUrl"]).to eq("http://site.com/ipn")
   end
 
   it "maps #date_of_month to ['dateOfMonth']" do
-    json["dateOfMonth"].should == 15
+    expect(json["dateOfMonth"]).to eq(15)
   end
 
   it "maps #day_of_week to ['dayOfWeek']" do
-    json["dayOfWeek"].should == "friday"
+    expect(json["dayOfWeek"]).to eq("friday")
   end
 
   it "maps #max_amount_per_payment to ['maxAmountPerPayment']" do
-    json["maxAmountPerPayment"].should == "60.00"
+    expect(json["maxAmountPerPayment"]).to eq("60.00")
   end
 
   it "maps #max_payments to ['maxNumberOfPayments']" do
-    json["maxNumberOfPayments"].should == 12
+    expect(json["maxNumberOfPayments"]).to eq(12)
   end
 
   it "maps #max_payments_per_period to ['maxNumberOfPaymentsPerPeriod']" do
-    json["maxNumberOfPaymentsPerPeriod"].should == 1
+    expect(json["maxNumberOfPaymentsPerPeriod"]).to eq(1)
   end
 
   it "maps #payment_period to ['paymentPeriod']" do
-    json["paymentPeriod"].should == "monthly"
+    expect(json["paymentPeriod"]).to eq("monthly")
   end
 
   it "maps #memo to ['memo']" do
-    json["memo"].should == "some memo"
+    expect(json["memo"]).to eq("some memo")
   end
 
   it "maps #sender_email to ['senderEmail']" do
-    json["senderEmail"].should == "sender@site.com"
+    expect(json["senderEmail"]).to eq("sender@site.com")
   end
 
   it "maps #pin_type to ['pinType']" do
-    json["pinType"].should == "required"
+    expect(json["pinType"]).to eq("required")
   end
 
   it "maps #fees_payer to ['feesPayer']" do
-    json["feesPayer"].should == "sender"
+    expect(json["feesPayer"]).to eq("sender")
   end
 
   it "maps #display_max_total_amount to ['displayMaxTotalAmount']" do
-    json["displayMaxTotalAmount"].should == false
+    expect(json["displayMaxTotalAmount"]).to eq(false)
   end
 
   it "does not include omitted parameters" do
     request.max_amount_per_payment = nil
-    json.should_not have_key("maxAmountPerPayment")
+    expect(json).not_to have_key("maxAmountPerPayment")
   end
 end

--- a/spec/public/preapproval_response_spec.rb
+++ b/spec/public/preapproval_response_spec.rb
@@ -9,6 +9,6 @@ describe AdaptivePayments::PreapprovalResponse do
   end
 
   it "maps ['preapprovalKey'] to #preapproval_key" do
-    response.preapproval_key.should == "SOME-KEY"
+    expect(response.preapproval_key).to eq("SOME-KEY")
   end
 end

--- a/spec/public/refund_request_spec.rb
+++ b/spec/public/refund_request_spec.rb
@@ -4,7 +4,11 @@ describe AdaptivePayments::RefundRequest do
   it_behaves_like "a RequestEnvelope"
 
   subject         { AdaptivePayments::RefundRequest }
-  its(:operation) { should == :Refund }
+
+  describe '#operation' do
+    subject { super().operation }
+    it { is_expected.to eq(:Refund) }
+  end
 
   let(:request) do
     AdaptivePayments::RefundRequest.new(
@@ -20,38 +24,38 @@ describe AdaptivePayments::RefundRequest do
   let(:json) { JSON.parse(request.to_json) }
 
   it "maps #currency_code to ['currencyCode']" do
-    json["currencyCode"].should == "USD"
+    expect(json["currencyCode"]).to eq("USD")
   end
 
   it "maps #pay_key to ['payKey']" do
-    json["payKey"].should == "ABCD-1234"
+    expect(json["payKey"]).to eq("ABCD-1234")
   end
 
   it "maps #tracking_id to ['trackingId']" do
-    json["trackingId"].should == "some.id"
+    expect(json["trackingId"]).to eq("some.id")
   end
 
   it "maps #transaction_id to ['transactionId']" do
-    json["transactionId"].should == "trans123"
+    expect(json["transactionId"]).to eq("trans123")
   end
 
   it "maps #ipn_notification_url to ['ipnNotificationUrl']" do
-    json["ipnNotificationUrl"].should == "http://site.com/ipn"
+    expect(json["ipnNotificationUrl"]).to eq("http://site.com/ipn")
   end
 
   it "maps #receivers.first.email to ['receiverList']['receiver'][0]['email']" do
-    json["receiverList"]["receiver"][0]["email"].should == "first@site.com"
+    expect(json["receiverList"]["receiver"][0]["email"]).to eq("first@site.com")
   end
 
   it "maps #receivers.first.amount to ['receiverList']['receiver'][0]['amount']" do
-    json["receiverList"]["receiver"][0]["amount"].should == "10.00"
+    expect(json["receiverList"]["receiver"][0]["amount"]).to eq("10.00")
   end
 
   it "maps #receivers.last.email to ['receiverList']['receiver'][1]['email']" do
-    json["receiverList"]["receiver"][1]["email"].should == "other@site.com"
+    expect(json["receiverList"]["receiver"][1]["email"]).to eq("other@site.com")
   end
 
   it "maps #receivers.last.amount to ['receiverList']['receiver'][1]['amount']" do
-    json["receiverList"]["receiver"][1]["amount"].should == "2.00"
+    expect(json["receiverList"]["receiver"][1]["amount"]).to eq("2.00")
   end
 end

--- a/spec/public/refund_response_spec.rb
+++ b/spec/public/refund_response_spec.rb
@@ -47,70 +47,70 @@ describe AdaptivePayments::RefundResponse do
   end
 
   it "maps ['currencyCode'] to #currency_code" do
-    response.currency_code.should == "GBP"
+    expect(response.currency_code).to eq("GBP")
   end
 
   it "maps ['refundInfoList']['refundInfo'][0]['receiver']['email'] to #refund_info.first.receiver_email" do
-    response.refund_info.first.receiver_email.should == "bob@site.com"
+    expect(response.refund_info.first.receiver_email).to eq("bob@site.com")
   end
 
   it "maps ['refundInfoList']['refundInfo'][0]['receiver']['amount'] to #refund_info.first.receiver_amount" do
-    response.refund_info.first.receiver_amount.should == BigDecimal("20.00")
+    expect(response.refund_info.first.receiver_amount).to eq(BigDecimal("20.00"))
   end
 
   it "maps ['refundInfoList']['refundInfo'][0]['receiver']['invoiceId'] to #refund_info.first.invoice_id" do
-    response.refund_info.first.invoice_id.should == "77"
+    expect(response.refund_info.first.invoice_id).to eq("77")
   end
 
   it "maps ['refundInfoList']['refundInfo'][1]['receiver']['amount'] to #refund_info.last.receiver_amount" do
-    response.refund_info.last.receiver_amount.should == BigDecimal("10.00")
+    expect(response.refund_info.last.receiver_amount).to eq(BigDecimal("10.00"))
   end
 
   it "maps ['refundInfoList']['refundInfo'][1]['receiver']['paymentType'] to #refund_info.last.payment_type" do
-    response.refund_info.last.payment_type.should == "DIGITALGOODS"
+    expect(response.refund_info.last.payment_type).to eq("DIGITALGOODS")
   end
 
   it "maps ['refundInfoList']['refundInfo'][0]['refundStatus'] to #refund_info.first.refund_status" do
-    response.refund_info.first.refund_status.should == "Pending"
+    expect(response.refund_info.first.refund_status).to eq("Pending")
   end
 
   it "maps ['refundInfoList']['refundInfo'][1]['refundStatus'] to #refund_info.last.refund_status" do
-    response.refund_info.last.refund_status.should == "Completed"
+    expect(response.refund_info.last.refund_status).to eq("Completed")
   end
 
   it "maps ['refundInfoList']['refundInfo'][0]['refundNetAmount'] to #refund_info.first.refund_net_amount" do
-    response.refund_info.first.refund_net_amount.should == BigDecimal("19.20")
+    expect(response.refund_info.first.refund_net_amount).to eq(BigDecimal("19.20"))
   end
 
   it "maps ['refundInfoList']['refundInfo'][0]['refundFeeAmount'] to #refund_info.first.refund_fee_amount" do
-    response.refund_info.first.refund_fee_amount.should == BigDecimal("0.80")
+    expect(response.refund_info.first.refund_fee_amount).to eq(BigDecimal("0.80"))
   end
 
   it "maps ['refundInfoList']['refundInfo'][0]['refundGrossAmount'] to #refund_info.first.refund_gross_amount" do
-    response.refund_info.first.refund_gross_amount.should == BigDecimal("20.00")
+    expect(response.refund_info.first.refund_gross_amount).to eq(BigDecimal("20.00"))
   end
 
   it "maps ['refundInfoList']['refundInfo'][0]['totalOfAllRefunds'] to #refund_info.first.total_of_all_refunds" do
-    response.refund_info.first.total_of_all_refunds.should == BigDecimal("20.00")
+    expect(response.refund_info.first.total_of_all_refunds).to eq(BigDecimal("20.00"))
   end
 
   it "maps ['refundInfoList']['refundInfo'][0]['refundHasBecomeFull'] to #refund_info.first.refund_has_become_full? " do
-    response.refund_info.first.refund_has_become_full?.should be_true
+    expect(response.refund_info.first.refund_has_become_full?).to be_truthy
   end
 
   it "maps ['refundInfoList']['refundInfo'][0]['encryptedRefundTransactionId'] to #refund_info.first.encrypted_refund_transaction_id" do
-    response.refund_info.first.encrypted_refund_transaction_id.should == "abc123"
+    expect(response.refund_info.first.encrypted_refund_transaction_id).to eq("abc123")
   end
 
   it "maps ['refundInfoList']['refundInfo'][0]['refundTransactionStatus'] to #refund_info.first.refund_transaction_status" do
-    response.refund_info.first.refund_transaction_status.should == "Pending"
+    expect(response.refund_info.first.refund_transaction_status).to eq("Pending")
   end
 
   it "maps ['refundInfoList']['refundInfo'][0]['errorList']['error'][0]['errorId'] to #refundInfo.first.errors.first.id" do
-    response.refund_info.first.errors.first.id.should == "err123"
+    expect(response.refund_info.first.errors.first.id).to eq("err123")
   end
 
   it "maps ['refundInfoList']['refundInfo'][0]['errorList']['error'][0]['domain'] to #refund_info.first.errors.first.domain" do
-    response.refund_info.first.errors.first.domain.should == "APPLICATION"
+    expect(response.refund_info.first.errors.first.domain).to eq("APPLICATION")
   end
 end

--- a/spec/public/set_payment_options_request_spec.rb
+++ b/spec/public/set_payment_options_request_spec.rb
@@ -4,7 +4,11 @@ describe AdaptivePayments::SetPaymentOptionsRequest do
   it_behaves_like "a RequestEnvelope"
 
   subject         { AdaptivePayments::SetPaymentOptionsRequest }
-  its(:operation) { should == :SetPaymentOptions }
+
+  describe '#operation' do
+    subject { super().operation }
+    it { is_expected.to eq(:SetPaymentOptions) }
+  end
 
   let(:request) do
     AdaptivePayments::SetPaymentOptionsRequest.new(
@@ -47,90 +51,90 @@ describe AdaptivePayments::SetPaymentOptionsRequest do
   let(:json)  { JSON.parse(request.to_json) }
 
   it "maps #pay_key to ['payKey']" do
-    json["payKey"].should == "ABCD-1234"
+    expect(json["payKey"]).to eq("ABCD-1234")
   end
 
   it "maps #institution_id to ['initiatingEntity']['institutionCustomer']['institutionId']" do
-    json["initiatingEntity"]["institutionCustomer"]["institutionId"].should == "inst123"
+    expect(json["initiatingEntity"]["institutionCustomer"]["institutionId"]).to eq("inst123")
   end
 
   it "maps #customer_first_name to ['initiatingEntity']['institutionCustomer']['firstName']" do
-    json["initiatingEntity"]["institutionCustomer"]["firstName"].should == "Bob"
+    expect(json["initiatingEntity"]["institutionCustomer"]["firstName"]).to eq("Bob")
   end
 
   it "maps #customer_last_name to ['initiatingEntity']['institutionCustomer']['lastName']" do
-    json["initiatingEntity"]["institutionCustomer"]["lastName"].should == "Cat"
+    expect(json["initiatingEntity"]["institutionCustomer"]["lastName"]).to eq("Cat")
   end
 
   it "maps #customer_display_name to ['initiatingEntity']['institutionCustomer']['displayName']" do
-    json["initiatingEntity"]["institutionCustomer"]["displayName"].should == "Bobcat"
+    expect(json["initiatingEntity"]["institutionCustomer"]["displayName"]).to eq("Bobcat")
   end
 
   it "maps #institution_customer_id to ['initiatingEntity']['institutionCustomer']['institutionCustomerId']" do
-    json["initiatingEntity"]["institutionCustomer"]["institutionCustomerId"].should == "77"
+    expect(json["initiatingEntity"]["institutionCustomer"]["institutionCustomerId"]).to eq("77")
   end
 
   it "maps #customer_country_code to ['initiatingEntity']['institutionCustomer']['countryCode']" do
-    json["initiatingEntity"]["institutionCustomer"]["countryCode"].should == "AU"
+    expect(json["initiatingEntity"]["institutionCustomer"]["countryCode"]).to eq("AU")
   end
 
   it "maps #customer_email to ['initiatingEntity']['institutionCustomer']['email']" do
-    json["initiatingEntity"]["institutionCustomer"]["email"].should == "bob@site.com"
+    expect(json["initiatingEntity"]["institutionCustomer"]["email"]).to eq("bob@site.com")
   end
 
   it "maps #email_header_image_url to ['displayOptions']['emailHeaderImageUrl']" do
-    json["displayOptions"]["emailHeaderImageUrl"].should == "http://site.com/email.png"
+    expect(json["displayOptions"]["emailHeaderImageUrl"]).to eq("http://site.com/email.png")
   end
 
   it "maps #email_marketing_image_url to ['displayOptions']['emailMarketingImageUrl']" do
-    json["displayOptions"]["emailMarketingImageUrl"].should == "http://site.com/marketing.png"
+    expect(json["displayOptions"]["emailMarketingImageUrl"]).to eq("http://site.com/marketing.png")
   end
 
   it "maps #header_image_url to ['displayOptions']['headerImageUrl']" do
-    json["displayOptions"]["headerImageUrl"].should == "http://site.com/header.png"
+    expect(json["displayOptions"]["headerImageUrl"]).to eq("http://site.com/header.png")
   end
 
   it "maps #shipping_address_id to ['shippingAddressId']" do
-    json["shippingAddressId"].should == "addr123"
+    expect(json["shippingAddressId"]).to eq("addr123")
   end
 
   it "maps #require_shipping_address_selection?  to ['senderOptions']['requireShippingAddressSelection']" do
-    json["senderOptions"]["requireShippingAddressSelection"].should be_true
+    expect(json["senderOptions"]["requireShippingAddressSelection"]).to be_truthy
   end
 
   it "maps #receiver_options.first.description to ['receiverOptions'][0]['description']" do
-    json["receiverOptions"][0]["description"].should == "Primary receiver"
+    expect(json["receiverOptions"][0]["description"]).to eq("Primary receiver")
   end
 
   it "maps #receiver_options.first.custom_id to ['receiverOptions'][0]['customId']" do
-    json["receiverOptions"][0]["customId"].should == "cust123"
+    expect(json["receiverOptions"][0]["customId"]).to eq("cust123")
   end
 
   it "maps #receiver_options.first.invoice_data.total_tax to ['receiverOptions'][0]['invoiceData']['totalTax']" do
-    json["receiverOptions"][0]["invoiceData"]["totalTax"].should == "2.00"
+    expect(json["receiverOptions"][0]["invoiceData"]["totalTax"]).to eq("2.00")
   end
 
   it "maps #receiver_options.first.invoice_data.total_shipping to ['receiverOptions'][0]['invoiceData']['totalShipping']" do
-    json["receiverOptions"][0]["invoiceData"]["totalShipping"].should == "0.00"
+    expect(json["receiverOptions"][0]["invoiceData"]["totalShipping"]).to eq("0.00")
   end
 
   it "maps #receiver_options.first.invoice_data.items.first.name to ['receiverOptions'][0]['invoiceData']['item'][0]['name']" do
-    json["receiverOptions"][0]["invoiceData"]["item"][0]["name"].should == "Video Game"
+    expect(json["receiverOptions"][0]["invoiceData"]["item"][0]["name"]).to eq("Video Game")
   end
 
   it "maps #receiver_options.first.invoice_data.items.first.identifier to ['receiverOptions'][0]['invoiceData']['item'][0]['identifier']" do
-    json["receiverOptions"][0]["invoiceData"]["item"][0]["identifier"].should == "ident123"
+    expect(json["receiverOptions"][0]["invoiceData"]["item"][0]["identifier"]).to eq("ident123")
   end
 
   it "maps #receiver_options.first.invoice_data.items.first.price to ['receiverOptions'][0]['invoiceData']['item'][0]['price']" do
-    json["receiverOptions"][0]["invoiceData"]["item"][0]["price"].should == "20.00"
+    expect(json["receiverOptions"][0]["invoiceData"]["item"][0]["price"]).to eq("20.00")
   end
 
   it "maps #receiver_options.first.invoice_data.items.first.item_price to ['receiverOptions'][0]['invoiceData']['item'][0]['itemPrice']" do
-    json["receiverOptions"][0]["invoiceData"]["item"][0]["itemPrice"].should == "10.00"
+    expect(json["receiverOptions"][0]["invoiceData"]["item"][0]["itemPrice"]).to eq("10.00")
   end
 
   it "maps #receiver_options.first.invoice_data.items.first.item_count to ['receiverOptions'][0]['invoiceData']['item'][0]['itemCount']" do
-    json["receiverOptions"][0]["invoiceData"]["item"][0]["itemCount"].should == 2
+    expect(json["receiverOptions"][0]["invoiceData"]["item"][0]["itemCount"]).to eq(2)
   end
 end

--- a/spec/shared/a_fault_message.rb
+++ b/spec/shared/a_fault_message.rb
@@ -23,38 +23,38 @@ shared_examples "a FaultMessage" do
   end
 
   it "maps ['error'][0]['errorId'] to #error_id" do
-    response.error_id.should == 1234
+    expect(response.error_id).to eq(1234)
   end
 
   it "maps ['error'][0]['domain'] to #error_domain" do
-    response.error_domain.should == "PLATFORM"
+    expect(response.error_domain).to eq("PLATFORM")
   end
 
   it "maps ['error'][0]['subdomain'] to #error_subdomain" do
-    response.error_subdomain.should == "Application"
+    expect(response.error_subdomain).to eq("Application")
   end
 
   it "maps ['error'][0]['severity'] to #error_severity" do
-    response.error_severity.should == "Error"
+    expect(response.error_severity).to eq("Error")
   end
 
   it "maps ['error'][0]['category'] to #error_category" do
-    response.error_category.should == "Application"
+    expect(response.error_category).to eq("Application")
   end
 
   it "maps ['error'][0]['message'] to #error_message" do
-    response.error_message.should == "An error message"
+    expect(response.error_message).to eq("An error message")
   end
 
   it "maps ['error'][0]['parameter'][0] to #error_parameters.first" do
-    response.error_parameters.first.should == "X-HEADER-FIELD"
+    expect(response.error_parameters.first).to eq("X-HEADER-FIELD")
   end
 
   it "maps ['error'][0]['parameter'][1] to #error_parameters.last" do
-    response.error_parameters.last.should == "X-OTHER-FIELD"
+    expect(response.error_parameters.last).to eq("X-OTHER-FIELD")
   end
 
   it "allows access to additional errors via #errors" do
-    response.errors.last.id.should == 2345
+    expect(response.errors.last.id).to eq(2345)
   end
 end

--- a/spec/shared/a_request_envelope.rb
+++ b/spec/shared/a_request_envelope.rb
@@ -5,10 +5,10 @@ shared_examples "a RequestEnvelope" do
   let(:json)    { JSON.parse(request.to_json) }
 
   it "maps #detail_level to ['requestEnvelope']['detailLevel']" do
-    json["requestEnvelope"]["detailLevel"].should == "ReturnAll"
+    expect(json["requestEnvelope"]["detailLevel"]).to eq("ReturnAll")
   end
 
   it "includes 'en_US' as the ['errorLanguage']" do
-    json["requestEnvelope"]["errorLanguage"].should == "en_US"
+    expect(json["requestEnvelope"]["errorLanguage"]).to eq("en_US")
   end
 end

--- a/spec/shared/a_response_envelope.rb
+++ b/spec/shared/a_response_envelope.rb
@@ -15,22 +15,22 @@ shared_examples "a ResponseEnvelope" do
   end
 
   it "maps ['responseEnvelope']['ack'] to #ack_code" do # 
-    response.ack_code.should == "Success"
+    expect(response.ack_code).to eq("Success")
   end
 
   it "maps ['responseEnvelope']['build'] to #build" do
-    response.build.should == "123456"
+    expect(response.build).to eq("123456")
   end
 
   it "maps ['responseEnvelope']['timestamp'] to #time" do
-    response.time.should == DateTime.new(2011, 9, 21)
+    expect(response.time).to eq(DateTime.new(2011, 9, 21))
   end
 
   it "maps ['responseEnvelope']['correlationId'] to #correlation_id" do
-    response.correlation_id.should == "1234"
+    expect(response.correlation_id).to eq("1234")
   end
 
   it "provides predicate methods for the ack code" do
-    response.success?.should be_true
+    expect(response.success?).to be_truthy
   end
 end


### PR DESCRIPTION
gemspec currently specifies a version of RSpec `>= 2.10`, which is allowing TravisCI to run rspecs with RSpec 3.1.

This is the result of updating the RSpec version dependency and running [transpec](https://github.com/yujinakayama/transpec).
